### PR TITLE
Alpha and Beta on justifying the belief of Beta Distribution

### DIFF
--- a/beta_binomial.py
+++ b/beta_binomial.py
@@ -1,0 +1,30 @@
+# beta_binomial.py
+
+import numpy as np
+from scipy import stats 
+from matplotlib import pyplot as plt 
+
+if __name__ == "__main__":
+    number_of_trials = [0,2,10,20,50,500]
+    data = stats.bernoulli.rvs(0.5, size = number_of_trials[-1])
+
+    x = np.linspace(0, 1, 100)
+
+    for i, N in enumerate(number_of_trials):
+        heads = data[:N].sum()
+
+        ax = plt.subplot(len(number_of_trials) // 2, 2, i+1)
+        ax.set_title("%s trials, %s heads" % (N, heads))
+
+        plt.xlabel("$P(H)$, Probability of Heads")
+        plt.ylabel("Density")
+        if i == 0: 
+            plt.ylim([0.0, 2.0])
+        plt.setp(ax.get_yticklabels(), visible=False)
+
+        y = stats.beta.pdf(x, 1 + heads, 1 + N - heads)
+        plt.plot(x, y, label = "observe %d tosses, \n %d heads" % (N, heads))
+        plt.fill_between(x, 0, y, color = "#aaaadd", alpha = 0.5)
+
+plt.tight_layout()
+plt.show()

--- a/beta_distribution.py
+++ b/beta_distribution.py
@@ -1,0 +1,25 @@
+import numpy as np 
+from scipy.stats import beta 
+import matplotlib.pyplot as plt 
+import seaborn as sns 
+
+
+if __name__ == "__main__":
+    sns.set_palette("deep", desat=.6)
+    sns.set_context(rc={"figure.figsize": (8,4)})
+    x = np.linspace(0,1,100)
+    params = [
+        (0.5, 0.5),
+        (1,1),
+        (4,3),
+        (2,5),
+        (6,6)
+    ]
+
+    for p in params: 
+        y = beta.pdf(x, p[0], p[1])
+        plt.plot(x, y, label="$\\alpha=%s$, $\\beta=%s$" % p)
+    plt.xlabel("$\\theta$, Fairness")
+    plt.ylabel("Đesity")
+    plt.legend(title = "Parameters")
+    plt.show()


### PR DESCRIPTION
Explains how Alpha (α) and Beta (β) in the Beta distribution represent prior belief and confidence in binary outcomes, and how they justify the shape of the distribution in Bayesian inference.